### PR TITLE
Mapped diagnostic context logging

### DIFF
--- a/commons/src/main/resources/logback.xml
+++ b/commons/src/main/resources/logback.xml
@@ -19,7 +19,7 @@
             </TimeBasedFileNamingAndTriggeringPolicy>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{40} %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %-5level %logger{40} %X{userId}- %msg%n</pattern>
         </encoder>
     </appender>
 
@@ -36,7 +36,7 @@
             </TimeBasedFileNamingAndTriggeringPolicy>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{40} %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %-5level %logger{40} %X{userId}- %msg%n</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>
@@ -46,7 +46,7 @@
     
     <appender class="ch.qos.logback.core.ConsoleAppender" name="CONSOLE">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{40} %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %-5level %logger{40} %X{userId}- %msg%n</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/consumer/bean/ExchangeMessageConsumerBean.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/consumer/bean/ExchangeMessageConsumerBean.java
@@ -15,6 +15,7 @@ import eu.europa.ec.fisheries.schema.exchange.module.v1.ExchangeBaseRequest;
 import eu.europa.ec.fisheries.schema.exchange.plugin.v1.AcknowledgeResponse;
 import eu.europa.ec.fisheries.schema.exchange.plugin.v1.PingResponse;
 import eu.europa.ec.fisheries.uvms.commons.message.api.MessageConstants;
+import eu.europa.ec.fisheries.uvms.commons.message.context.MappedDiagnosticContext;
 import eu.europa.ec.fisheries.uvms.exchange.message.event.ErrorEvent;
 import eu.europa.ec.fisheries.uvms.exchange.message.event.ExchangeLogEvent;
 import eu.europa.ec.fisheries.uvms.exchange.message.event.HandleProcessedMovementEvent;
@@ -184,6 +185,7 @@ public class ExchangeMessageConsumerBean implements MessageListener {
     @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
     public void onMessage(Message message) {
         TextMessage textMessage = (TextMessage) message;
+        MappedDiagnosticContext.addMessagePropertiesToThreadMappedDiagnosticContext(textMessage);
         ExchangeBaseRequest request = tryConsumeExchangeBaseRequest(textMessage);
         LOG.info("Message received in Exchange Message MDB");
         LOG.debug("Request body : ", request);

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/producer/bean/ExchangeMessageProducerBean.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/producer/bean/ExchangeMessageProducerBean.java
@@ -132,8 +132,8 @@ public class ExchangeMessageProducerBean extends AbstractProducer implements Exc
         try {
             LOG.debug("Sending error message back from Exchange module to recipient om JMS Queue with correlationID: {} ", message.getJmsMessage().getJMSMessageID());
             String data = JAXBMarshaller.marshallJaxBObjectToString(message.getErrorFault());
-            this.sendModuleResponseMessage(message.getJmsMessage(), data);
-        } catch (ExchangeModelMapperException | JMSException e) {
+            this.sendResponseMessageToSender(message.getJmsMessage(), data);
+        } catch (ExchangeModelMapperException | JMSException | MessageException e) {
             LOG.error("Error when returning Error message to recipient");
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
         <!-- Uvms models -->
         <asset.model.version>4.0.10</asset.model.version>
-        <exchange.model.version>4.0.11-SNAPSHOT</exchange.model.version>
+        <exchange.model.version>4.0.12-SNAPSHOT</exchange.model.version>
         <audit.model.version>4.0.6</audit.model.version>
         <movement.model.version>4.0.9</movement.model.version>
         <rules.model.version>3.0.23-SNAPSHOT</rules.model.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
         <!-- Uvms libs -->
         <longpolling.version>2.0.13</longpolling.version>
-        <uvms.commons.version>3.0.15</uvms.commons.version>
+        <uvms.commons.version>3.0.17-SNAPSHOT</uvms.commons.version>
         <uvms.config.version>4.0.0</uvms.config.version>
         <usm4uvms.version>4.0.8</usm4uvms.version>
         <uvms-pom-deps.version>1.16</uvms-pom-deps.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
         <!-- Uvms libs -->
         <longpolling.version>2.0.13</longpolling.version>
-        <uvms.commons.version>3.0.17-SNAPSHOT</uvms.commons.version>
+        <uvms.commons.version>3.0.17</uvms.commons.version>
         <uvms.config.version>4.0.0</uvms.config.version>
         <usm4uvms.version>4.0.8</usm4uvms.version>
         <uvms-pom-deps.version>1.16</uvms-pom-deps.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         
         <!-- Uvms libs -->
         <longpolling.version>2.0.13</longpolling.version>
-        <uvms.commons.version>3.0.12</uvms.commons.version>
+        <uvms.commons.version>3.0.14-SNAPSHOT</uvms.commons.version>
         <uvms.config.version>4.0.0</uvms.config.version>
         <usm4uvms.version>4.0.8</usm4uvms.version>
         <uvms-pom-deps.version>1.16</uvms-pom-deps.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <groupId>fish.focus.uvms.maven</groupId>
         <artifactId>uvms-pom</artifactId>
-        <version>1.17-SNAPSHOT</version>
+        <version>1.17</version>
         <relativePath />
     </parent>
 
     <groupId>eu.europa.ec.fisheries.uvms.exchange</groupId>
     <artifactId>exchange</artifactId>
-    <version>4.0.12-SNAPSHOT</version>
+    <version>4.0.13-SNAPSHOT</version>
     <packaging>pom</packaging>
     
     <scm>
@@ -42,7 +42,7 @@
         <exchange.model.version>4.0.11</exchange.model.version>
         <audit.model.version>4.0.6</audit.model.version>
         <movement.model.version>4.0.9</movement.model.version>
-        <rules.model.version>3.0.23-SNAPSHOT</rules.model.version>
+        <rules.model.version>3.0.23</rules.model.version>
 
         <asset.version>4.0.9</asset.version>
 


### PR DESCRIPTION
The Union commons message library has been extended with Mapped diagnostic context functionality.
The Mapped diagnostic context data (MDC) could be attached to the processing thread of an initiating request message flow.
The JMS message properties will be used to help the MDC data travel between Union modules.
The MDC  parameter: requestId has been added as a logging pattern in the logback logging configuration.
This enables us to have a message flow trace available in Union for log aggregation purposes.