### PR TITLE
Log mdc tracer in log table + make it possible to communicate with the FLUXVESSEL-Plugin

### DIFF
--- a/LIQUIBASE/changelog/db-changelog-master.xml
+++ b/LIQUIBASE/changelog/db-changelog-master.xml
@@ -7,6 +7,8 @@
     <include file="changelog\properties.xml"/>
     
     <include file="changelog\v0.1\db-changelog-createTables_0.1.xml" />
+    <include file="changelog\v0.2\db-changelog-createTables_0.2.xml" />
+
     <include file="changelog\v0.1\db-changelog-insertInitdata_0.1.xml" />
     <include file="changelog\v0.1\db-changelog-insertTestdata_0.1.xml" />
 

--- a/LIQUIBASE/changelog/v0.2/db-changelog-createTables_0.2.xml
+++ b/LIQUIBASE/changelog/v0.2/db-changelog-createTables_0.2.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <include file="\schema\tables\v0.2\exchangelog.xml"/>
+
+</databaseChangeLog>

--- a/LIQUIBASE/schema/tables/v0.2/exchangelog.xml
+++ b/LIQUIBASE/schema/tables/v0.2/exchangelog.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet author="stihft" id="Add column containing the MDC request id">
+        <addColumn tableName="log">
+            <column name="log_mdc_request_id" type="varchar(36)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="log" columnName="log_mdc_request_id" />
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>	

--- a/domain/src/main/java/eu/europa/ec/fisheries/uvms/exchange/entity/exchangelog/ExchangeLog.java
+++ b/domain/src/main/java/eu/europa/ec/fisheries/uvms/exchange/entity/exchangelog/ExchangeLog.java
@@ -124,6 +124,9 @@ public class ExchangeLog {
 	@Column(name="log_destination")
 	private String destination;
 
+	@Size(max=36)
+	@Column(name="log_mdc_request_id")
+	private String mdcRequestId;
 
 	@PrePersist
 	public void prepersist() {
@@ -273,4 +276,9 @@ public class ExchangeLog {
 	public void setDestination(String destination) {
 		this.destination = destination;
 	}
+
+	public void setMDCRequestId(String mdcRequestId) {
+		this.mdcRequestId = mdcRequestId;
+	}
+
 }

--- a/domain/src/main/java/eu/europa/ec/fisheries/uvms/exchange/mapper/LogMapper.java
+++ b/domain/src/main/java/eu/europa/ec/fisheries/uvms/exchange/mapper/LogMapper.java
@@ -24,6 +24,8 @@ import eu.europa.ec.fisheries.schema.exchange.v1.SendPollType;
 import eu.europa.ec.fisheries.uvms.exchange.entity.exchangelog.ExchangeLog;
 import eu.europa.ec.fisheries.uvms.exchange.entity.exchangelog.ExchangeLogStatus;
 import eu.europa.ec.fisheries.uvms.exchange.model.util.DateUtils;
+import org.slf4j.MDC;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -95,7 +97,7 @@ public class LogMapper {
         entity.setUpdateTime(DateUtils.nowUTC().toDate());
         entity.setType(log.getType());
         entity.setDestination(log.getDestination());
-
+        entity.setMDCRequestId(MDC.get("requestId"));
         return entity;
     }
 

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/consumer/bean/ExchangeMessageConsumerBean.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/consumer/bean/ExchangeMessageConsumerBean.java
@@ -15,33 +15,7 @@ import eu.europa.ec.fisheries.schema.exchange.module.v1.ExchangeBaseRequest;
 import eu.europa.ec.fisheries.schema.exchange.plugin.v1.AcknowledgeResponse;
 import eu.europa.ec.fisheries.schema.exchange.plugin.v1.PingResponse;
 import eu.europa.ec.fisheries.uvms.commons.message.api.MessageConstants;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.ErrorEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.ExchangeLogEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.HandleProcessedMovementEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.LogIdByTypeExists;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.LogRefIdByTypeExists;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.MdrSyncRequestMessageEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.MdrSyncResponseMessageEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.PingEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.PluginConfigEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.PluginPingEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.ReceiveInvalidSalesMessageEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.ReceiveSalesQueryEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.ReceiveSalesReportEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.ReceiveSalesResponseEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.ReceivedFluxFaResponseMessageEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendCommandToPluginEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendFLUXFAResponseToPluginEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendFaQueryToPluginEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendFaReportToPluginEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendReportToPluginEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendSalesReportEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendSalesResponseEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SetFaQueryMessageEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SetFluxFAReportMessageEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SetMovementEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.UpdateLogStatusEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.UpdatePluginSettingEvent;
+import eu.europa.ec.fisheries.uvms.exchange.message.event.*;
 import eu.europa.ec.fisheries.uvms.exchange.message.event.carrier.ExchangeMessageEvent;
 import eu.europa.ec.fisheries.uvms.exchange.model.constant.FaultCode;
 import eu.europa.ec.fisheries.uvms.exchange.model.exception.ExchangeModelMarshallException;
@@ -99,6 +73,10 @@ public class ExchangeMessageConsumerBean implements MessageListener {
     @Inject
     @SendSalesReportEvent
     private Event<ExchangeMessageEvent> sendSalesReportEvent;
+
+    @Inject
+    @ReceiveAssetInformationEvent
+    private Event<ExchangeMessageEvent> receiveAssetInformationEvent;
 
     @Inject
     @SendSalesResponseEvent
@@ -241,6 +219,9 @@ public class ExchangeMessageConsumerBean implements MessageListener {
                     break;
                 case UPDATE_PLUGIN_SETTING:
                     updatePluginSettingEvent.fire(messageEventWrapper);
+                    break;
+                case RECEIVE_ASSET_INFORMATION:
+                    receiveAssetInformationEvent.fire(messageEventWrapper);
                     break;
                 case PING:
                     pingEvent.fire(messageEventWrapper);

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/consumer/bean/ExchangeMessageConsumerBean.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/consumer/bean/ExchangeMessageConsumerBean.java
@@ -79,6 +79,14 @@ public class ExchangeMessageConsumerBean implements MessageListener {
     private Event<ExchangeMessageEvent> receiveAssetInformationEvent;
 
     @Inject
+    @SendAssetInformationEvent
+    private Event<ExchangeMessageEvent> sendAssetInformationEvent;
+
+    @Inject
+    @QueryAssetInformationEvent
+    private Event<ExchangeMessageEvent> queryAssetInformationEvent;
+
+    @Inject
     @SendSalesResponseEvent
     private Event<ExchangeMessageEvent> sendSalesResponseEvent;
 
@@ -222,6 +230,12 @@ public class ExchangeMessageConsumerBean implements MessageListener {
                     break;
                 case RECEIVE_ASSET_INFORMATION:
                     receiveAssetInformationEvent.fire(messageEventWrapper);
+                    break;
+                case SEND_ASSET_INFORMATION:
+                    sendAssetInformationEvent.fire(messageEventWrapper);
+                    break;
+                case QUERY_ASSET_INFORMATION:
+                    queryAssetInformationEvent.fire(messageEventWrapper);
                     break;
                 case PING:
                     pingEvent.fire(messageEventWrapper);

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/event/QueryAssetInformationEvent.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/event/QueryAssetInformationEvent.java
@@ -1,0 +1,25 @@
+/*
+﻿Developed with the contribution of the European Commission - Directorate General for Maritime Affairs and Fisheries
+© European Union, 2015-2016.
+
+This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can
+redistribute it and/or modify it under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or any later version. The IFDM Suite is distributed in
+the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a
+copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.exchange.message.event;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE })
+public @interface QueryAssetInformationEvent {
+
+}

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/event/ReceiveAssetInformationEvent.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/event/ReceiveAssetInformationEvent.java
@@ -1,0 +1,25 @@
+/*
+﻿Developed with the contribution of the European Commission - Directorate General for Maritime Affairs and Fisheries
+© European Union, 2015-2016.
+
+This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can
+redistribute it and/or modify it under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or any later version. The IFDM Suite is distributed in
+the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a
+copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.exchange.message.event;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE })
+public @interface ReceiveAssetInformationEvent {
+
+}

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/event/SendAssetInformationEvent.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/event/SendAssetInformationEvent.java
@@ -1,0 +1,25 @@
+/*
+﻿Developed with the contribution of the European Commission - Directorate General for Maritime Affairs and Fisheries
+© European Union, 2015-2016.
+
+This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can
+redistribute it and/or modify it under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or any later version. The IFDM Suite is distributed in
+the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a
+copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.exchange.message.event;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE })
+public @interface SendAssetInformationEvent {
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <!-- Uvms models -->
         <asset.model.version>4.0.10</asset.model.version>
         <audit.model.version>4.0.6</audit.model.version>
-        <exchange.model.version>4.0.10</exchange.model.version>
+        <exchange.model.version>4.0.12-SNAPSHOT</exchange.model.version>
         <movement.model.version>4.0.9</movement.model.version>
         <rules.model.version>3.0.22</rules.model.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
         <!-- Uvms models -->
         <asset.model.version>4.0.10</asset.model.version>
-        <exchange.model.version>4.0.12</exchange.model.version>
+        <exchange.model.version>4.0.13-SNAPSHOT</exchange.model.version>
         <audit.model.version>4.0.6</audit.model.version>
         <movement.model.version>4.0.9</movement.model.version>
         <rules.model.version>3.0.23</rules.model.version>

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/exchange/service/ExchangeEventIncomingService.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/exchange/service/ExchangeEventIncomingService.java
@@ -49,6 +49,14 @@ public interface ExchangeEventIncomingService {
     void processMovement(@Observes @SetMovementEvent ExchangeMessageEvent message);
 
     /**
+     * Logs and sends a received asset information to Asset
+     *
+     * @param message received sales report
+     */
+    void receiveAssetInformation(@Observes @ReceiveAssetInformationEvent ExchangeMessageEvent message);
+
+
+    /**
      * Logs and sends a received sales report through to Rules
      *
      * @param message received sales report

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/exchange/service/ExchangeEventIncomingService.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/exchange/service/ExchangeEventIncomingService.java
@@ -51,10 +51,23 @@ public interface ExchangeEventIncomingService {
     /**
      * Logs and sends a received asset information to Asset
      *
-     * @param message received sales report
+     * @param message received asset information message
      */
     void receiveAssetInformation(@Observes @ReceiveAssetInformationEvent ExchangeMessageEvent message);
 
+    /**
+     * Logs and sends a send asset information to FLUX fleet plugin
+     *
+     * @param message send asset information message
+     */
+    void sendAssetInformation(@Observes @SendAssetInformationEvent ExchangeMessageEvent message);
+
+    /**
+     * Logs and sends a query asset information to FLUX fleet plugin
+     *
+     * @param message query asset information message
+     */
+    void queryAssetInformation(@Observes @QueryAssetInformationEvent ExchangeMessageEvent message);
 
     /**
      * Logs and sends a received sales report through to Rules

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/exchange/service/ExchangeEventOutgoingService.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/exchange/service/ExchangeEventOutgoingService.java
@@ -12,12 +12,8 @@
 package eu.europa.ec.fisheries.uvms.exchange.service;
 
 import eu.europa.ec.fisheries.schema.exchange.plugin.types.v1.PluginType;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.MdrSyncRequestMessageEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendCommandToPluginEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendFLUXFAResponseToPluginEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendFaQueryToPluginEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendFaReportToPluginEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendReportToPluginEvent;
+import eu.europa.ec.fisheries.schema.exchange.plugin.v1.PluginBaseRequest;
+import eu.europa.ec.fisheries.uvms.exchange.message.event.*;
 import eu.europa.ec.fisheries.uvms.exchange.message.event.carrier.ExchangeMessageEvent;
 import eu.europa.ec.fisheries.uvms.exchange.message.exception.ExchangeMessageException;
 import eu.europa.ec.fisheries.uvms.exchange.model.exception.ExchangeModelMarshallException;
@@ -75,4 +71,6 @@ public interface ExchangeEventOutgoingService {
     void sendFLUXFAQueryToPlugin(@Observes @SendFaQueryToPluginEvent ExchangeMessageEvent message);
 
     void sendFLUXFAReportToPlugin(@Observes @SendFaReportToPluginEvent ExchangeMessageEvent message);
+
+    void sendAssetInformationToFLUX(PluginBaseRequest request) throws ExchangeModelMarshallException, ExchangeMessageException;
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/exchange/service/bean/ExchangeEventOutgoingServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/exchange/service/bean/ExchangeEventOutgoingServiceBean.java
@@ -16,13 +16,11 @@ import static eu.europa.ec.fisheries.schema.exchange.plugin.types.v1.PluginType.
 import eu.europa.ec.fisheries.schema.exchange.common.v1.AcknowledgeType;
 import eu.europa.ec.fisheries.schema.exchange.common.v1.CommandType;
 import eu.europa.ec.fisheries.schema.exchange.common.v1.CommandTypeType;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.SendMovementToPluginRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.SetCommandRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.SetFAQueryMessageRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.SetFLUXFAReportMessageRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.SetFLUXFAResponseMessageRequest;
+import eu.europa.ec.fisheries.schema.exchange.module.v1.*;
 import eu.europa.ec.fisheries.schema.exchange.movement.v1.SendMovementToPluginType;
 import eu.europa.ec.fisheries.schema.exchange.plugin.types.v1.PluginType;
+import eu.europa.ec.fisheries.schema.exchange.plugin.v1.ExchangePluginMethod;
+import eu.europa.ec.fisheries.schema.exchange.plugin.v1.PluginBaseRequest;
 import eu.europa.ec.fisheries.schema.exchange.plugin.v1.SendSalesReportRequest;
 import eu.europa.ec.fisheries.schema.exchange.plugin.v1.SendSalesResponseRequest;
 import eu.europa.ec.fisheries.schema.exchange.service.v1.ServiceResponseType;
@@ -33,13 +31,7 @@ import eu.europa.ec.fisheries.schema.exchange.v1.LogType;
 import eu.europa.ec.fisheries.schema.exchange.v1.TypeRefType;
 import eu.europa.ec.fisheries.schema.exchange.v1.UnsentMessageTypeProperty;
 import eu.europa.ec.fisheries.uvms.exchange.message.consumer.ExchangeConsumer;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.ErrorEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.MdrSyncRequestMessageEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendCommandToPluginEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendFLUXFAResponseToPluginEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendFaQueryToPluginEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendFaReportToPluginEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendReportToPluginEvent;
+import eu.europa.ec.fisheries.uvms.exchange.message.event.*;
 import eu.europa.ec.fisheries.uvms.exchange.message.event.carrier.ExchangeMessageEvent;
 import eu.europa.ec.fisheries.uvms.exchange.message.exception.ExchangeMessageException;
 import eu.europa.ec.fisheries.uvms.exchange.message.producer.ExchangeMessageProducer;
@@ -60,6 +52,7 @@ import eu.europa.ec.fisheries.uvms.exchange.service.mapper.ExchangeLogMapper;
 import eu.europa.ec.fisheries.uvms.exchange.service.mapper.ExchangeToMdrRulesMapper;
 import eu.europa.ec.fisheries.wsdl.asset.types.Asset;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
@@ -109,6 +102,12 @@ public class ExchangeEventOutgoingServiceBean implements ExchangeEventOutgoingSe
     public void sendSalesReportToFLUX(SendSalesReportRequest sendSalesReportRequest) throws ExchangeModelMarshallException, ExchangeMessageException {
         String marshalledRequest = JAXBMarshaller.marshallJaxBObjectToString(sendSalesReportRequest);
         producer.sendEventBusMessage(marshalledRequest, ExchangeServiceConstants.FLUX_SALES_PLUGIN_SERVICE_NAME);
+    }
+
+    @Override
+    public void sendAssetInformationToFLUX(PluginBaseRequest request) throws ExchangeModelMarshallException, ExchangeMessageException {
+        String marshalledRequest = JAXBMarshaller.marshallJaxBObjectToString(request);
+        producer.sendEventBusMessage(marshalledRequest, ExchangeServiceConstants.FLUX_VESSEL_PLUGIN_SERVICE_NAME);
     }
 
     @Override

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/exchange/service/constants/ExchangeServiceConstants.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/exchange/service/constants/ExchangeServiceConstants.java
@@ -23,4 +23,5 @@ public class ExchangeServiceConstants {
     public static final String FLUX_SALES_PLUGIN_SERVICE_NAME = "eu.europa.ec.fisheries.uvms.plugins.flux.sales";
     public static final String BELGIAN_AUCTION_SALES_PLUGIN_SERVICE_NAME = "eu.europa.ec.fisheries.uvms.plugins.belgianauction.sales";
     public static final String MDR_PLUGIN_SERVICE_NAME = "eu.europa.ec.fisheries.uvms.plugins.mdr";
+    public static final String FLUX_VESSEL_PLUGIN_SERVICE_NAME = "eu.europa.ec.fisheries.uvms.plugins.flux.vessel";
 }


### PR DESCRIPTION
1) Add a column to persist the MDC tracer id, next to the other log information, in the log table
1) Add flows to support:
    - receiving vessel information from fleet
    - sending queries to fleet
    - sending vessel information to fleet (as response to the query)

