### PR TITLE
Performance improvement for Sales: make it possible to process Sales messages together with other types of messages

### DIFF
--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/consumer/bean/ExchangeMessageConsumerBean.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/consumer/bean/ExchangeMessageConsumerBean.java
@@ -187,7 +187,7 @@ public class ExchangeMessageConsumerBean implements MessageListener {
         TextMessage textMessage = (TextMessage) message;
         MappedDiagnosticContext.addMessagePropertiesToThreadMappedDiagnosticContext(textMessage);
         ExchangeBaseRequest request = tryConsumeExchangeBaseRequest(textMessage);
-        LOG.info("Message received in Exchange Message MDB");
+        LOG.info("Message received in Exchange Message MDB. Times redelivered: " + getTimesRedelivered(message));
         LOG.debug("Request body : ", request);
         final ExchangeMessageEvent messageEventWrapper = new ExchangeMessageEvent(textMessage);
         if (request == null) {
@@ -326,4 +326,12 @@ public class ExchangeMessageConsumerBean implements MessageListener {
         }
     }
 
+    private int getTimesRedelivered(Message message) {
+        try {
+            return (message.getIntProperty("JMSXDeliveryCount") - 1);
+
+        } catch (Exception e) {
+            return 0;
+        }
+    }
 }

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/consumer/bean/ExchangeMessageConsumerBean.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/consumer/bean/ExchangeMessageConsumerBean.java
@@ -16,38 +16,15 @@ import eu.europa.ec.fisheries.schema.exchange.plugin.v1.AcknowledgeResponse;
 import eu.europa.ec.fisheries.schema.exchange.plugin.v1.PingResponse;
 import eu.europa.ec.fisheries.uvms.commons.message.api.MessageConstants;
 import eu.europa.ec.fisheries.uvms.commons.message.context.MappedDiagnosticContext;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.ErrorEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.ExchangeLogEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.HandleProcessedMovementEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.LogIdByTypeExists;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.LogRefIdByTypeExists;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.MdrSyncRequestMessageEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.MdrSyncResponseMessageEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.PingEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.PluginConfigEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.PluginPingEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.ReceiveInvalidSalesMessageEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.ReceiveSalesQueryEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.ReceiveSalesReportEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.ReceiveSalesResponseEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.ReceivedFluxFaResponseMessageEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendCommandToPluginEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendFLUXFAResponseToPluginEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendFaQueryToPluginEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendFaReportToPluginEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendReportToPluginEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendSalesReportEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SendSalesResponseEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SetFaQueryMessageEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SetFluxFAReportMessageEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.SetMovementEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.UpdateLogStatusEvent;
-import eu.europa.ec.fisheries.uvms.exchange.message.event.UpdatePluginSettingEvent;
+import eu.europa.ec.fisheries.uvms.exchange.message.event.*;
 import eu.europa.ec.fisheries.uvms.exchange.message.event.carrier.ExchangeMessageEvent;
 import eu.europa.ec.fisheries.uvms.exchange.model.constant.FaultCode;
 import eu.europa.ec.fisheries.uvms.exchange.model.exception.ExchangeModelMarshallException;
 import eu.europa.ec.fisheries.uvms.exchange.model.mapper.ExchangeModuleResponseMapper;
 import eu.europa.ec.fisheries.uvms.exchange.model.mapper.JAXBMarshaller;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.ejb.ActivationConfigProperty;
 import javax.ejb.MessageDriven;
 import javax.ejb.TransactionAttribute;
@@ -57,8 +34,6 @@ import javax.inject.Inject;
 import javax.jms.Message;
 import javax.jms.MessageListener;
 import javax.jms.TextMessage;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 //@formatter:off
 @MessageDriven(mappedName = MessageConstants.QUEUE_EXCHANGE_EVENT, activationConfig = {
@@ -187,7 +162,7 @@ public class ExchangeMessageConsumerBean implements MessageListener {
         TextMessage textMessage = (TextMessage) message;
         MappedDiagnosticContext.addMessagePropertiesToThreadMappedDiagnosticContext(textMessage);
         ExchangeBaseRequest request = tryConsumeExchangeBaseRequest(textMessage);
-        LOG.info("Message received in Exchange Message MDB. Times redelivered: " + getTimesRedelivered(message));
+        LOG.debug("Message received in Exchange Message MDB. Times redelivered: " + getTimesRedelivered(message));
         LOG.debug("Request body : ", request);
         final ExchangeMessageEvent messageEventWrapper = new ExchangeMessageEvent(textMessage);
         if (request == null) {

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/producer/ExchangeMessageProducer.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/producer/ExchangeMessageProducer.java
@@ -33,6 +33,8 @@ public interface ExchangeMessageProducer {
 
     String sendRulesMessage(String text) throws ConfigMessageException;
 
+    String sendRulesMessage(String text, String messageSelector) throws ExchangeMessageException;
+
     void sendModuleErrorResponseMessage(@Observes @ErrorEvent ExchangeMessageEvent event);
 
     void sendPluginErrorResponseMessage(@Observes @PluginErrorEvent PluginMessageEvent event);

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/producer/bean/ExchangeRulesProducer.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/exchange/message/producer/bean/ExchangeRulesProducer.java
@@ -1,0 +1,26 @@
+/*
+Developed by the European Commission - Directorate General for Maritime Affairs and Fisheries @ European Union, 2015-2016.
+
+This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of
+the License, or any later version. The IFDM Suite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+package eu.europa.ec.fisheries.uvms.exchange.message.producer.bean;
+
+import eu.europa.ec.fisheries.uvms.commons.message.api.MessageConstants;
+import eu.europa.ec.fisheries.uvms.commons.message.impl.AbstractProducer;
+import javax.ejb.LocalBean;
+import javax.ejb.Stateless;
+
+@Stateless
+@LocalBean
+public class ExchangeRulesProducer extends AbstractProducer {
+
+    @Override
+    public String getDestinationName() {
+        return MessageConstants.QUEUE_MODULE_RULES;
+    }
+}

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/exchange/service/bean/ExchangeEventIncomingServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/exchange/service/bean/ExchangeEventIncomingServiceBean.java
@@ -294,8 +294,12 @@ public class ExchangeEventIncomingServiceBean implements ExchangeEventIncomingSe
         }
     }
 
-    private void forwardToRules(String messageToForward) {
-        forwardToRules(messageToForward, null, null);
+    private void forwardToRules(String messageToForward, ExchangeMessageEvent exchangeMessageEvent, ServiceResponseType service) {
+        forwardToRules(messageToForward, exchangeMessageEvent, service, null);
+    }
+
+    private void forwardToRules(String messageToForward, String messageSelector) {
+        forwardToRules(messageToForward, null, null, messageSelector);
     }
 
     /**
@@ -305,10 +309,11 @@ public class ExchangeEventIncomingServiceBean implements ExchangeEventIncomingSe
      * @param exchangeMessageEvent is optional
      * @param service              is optional
      */
-    private void forwardToRules(String messageToForward, ExchangeMessageEvent exchangeMessageEvent, ServiceResponseType service) {
+    private void forwardToRules(String messageToForward, ExchangeMessageEvent exchangeMessageEvent, ServiceResponseType service, String messageSelector) {
         try {
             log.info("[INFO] Forwarding the msg to rules Module.");
-            producer.sendMessageOnQueue(messageToForward, MessageQueue.RULES);
+            producer.sendRulesMessage(messageToForward, messageSelector);
+
         } catch (ExchangeMessageException e) {
             log.error("[ERROR] Failed to forward message to Rules: {} {}", messageToForward, e);
 
@@ -367,7 +372,9 @@ public class ExchangeEventIncomingServiceBean implements ExchangeEventIncomingSe
 
             ExchangeLogType log = exchangeLog.log(request, LogType.RECEIVE_SALES_REPORT, ExchangeLogStatusTypeType.ISSUED, TypeRefType.SALES_REPORT, report, true);
 
-            forwardToRules(RulesModuleRequestMapper.createReceiveSalesReportRequest(report, messageGuid, plugin.name(), log.getGuid(), sender, request.getOnValue()));
+            String receiveSalesReportRequest = RulesModuleRequestMapper.createReceiveSalesReportRequest(report, messageGuid, plugin.name(), log.getGuid(), sender, request.getOnValue());
+            String messageSelector = "ReceiveSalesReportRequest";
+            forwardToRules(receiveSalesReportRequest, messageSelector);
         } catch (ExchangeModelMarshallException e) {
             try {
                 String errorMessage = "Couldn't map to SetSalesReportRequest when processing sales report from plugin. The event was " + event.getJmsMessage().getText();
@@ -395,7 +402,9 @@ public class ExchangeEventIncomingServiceBean implements ExchangeEventIncomingSe
 
             ExchangeLogType log = exchangeLog.log(request, LogType.RECEIVE_SALES_QUERY, ExchangeLogStatusTypeType.ISSUED, TypeRefType.SALES_QUERY, query, true);
 
-            forwardToRules(RulesModuleRequestMapper.createReceiveSalesQueryRequest(query, messageGuid, plugin.name(), log.getGuid(), sender, request.getOnValue()));
+            String receiveSalesQueryRequest = RulesModuleRequestMapper.createReceiveSalesQueryRequest(query, messageGuid, plugin.name(), log.getGuid(), sender, request.getOnValue());
+            String messageSelector = "ReceiveSalesQueryRequest";
+            forwardToRules(receiveSalesQueryRequest, messageSelector);
 
         } catch (ExchangeModelMarshallException e) {
             try {
@@ -418,7 +427,9 @@ public class ExchangeEventIncomingServiceBean implements ExchangeEventIncomingSe
 
             ExchangeLogType log = exchangeLog.log(request, LogType.RECEIVE_SALES_RESPONSE, ExchangeLogStatusTypeType.ISSUED, TypeRefType.SALES_RESPONSE, response, true);
 
-            forwardToRules(RulesModuleRequestMapper.createReceiveSalesResponseRequest(response, log.getGuid(), request.getSenderOrReceiver()));
+            String receiveSalesResponseRequest = RulesModuleRequestMapper.createReceiveSalesResponseRequest(response, log.getGuid(), request.getSenderOrReceiver());
+            String messageSelector = "ReceiveSalesResponseRequest";
+            forwardToRules(receiveSalesResponseRequest, messageSelector);
         } catch (ExchangeModelMarshallException e) {
             firePluginFault(event, "Error when receiving a Sales response from FLUX", e);
         } catch (ExchangeLogException e) {

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/exchange/service/bean/ExchangeServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/exchange/service/bean/ExchangeServiceBean.java
@@ -218,10 +218,13 @@ public class ExchangeServiceBean implements ExchangeService {
         switch (status){
             case STARTED:
                 sendAuditLogMessageForServiceStatusStarted(compressServiceClassName(serviceName), username);
+                break;
             case STOPPED:
                 sendAuditLogMessageForServiceStatusStopped(compressServiceClassName(serviceName), username);
+                break;
             default:
                 sendAuditLogMessageForServiceStatusUnknown(compressServiceClassName(serviceName), username);
+                break;
         }
     }
 }


### PR DESCRIPTION
We've added a message selector, when sending a Sales message to Rules.
This makes speed improvements in Rules possible: the Sales messages can be handled concurrently with other types of messages.