### PR TITLE
Exchange screen doesn't show some incoming messages

### DIFF
--- a/LIQUIBASE/schema/tables/exchangelog.xml
+++ b/LIQUIBASE/schema/tables/exchangelog.xml
@@ -11,7 +11,7 @@
             <column name="log_guid" remarks="the id (guid) of the log" type="VARCHAR(36)">
                 <constraints nullable="false" unique="true"/>
             </column>
-            <column name="log_type_ref_guid" remarks="id for message causing the log" type="VARCHAR(36)"/>
+            <column name="log_type_ref_guid" remarks="id for message causing the log" type="VARCHAR"/>
             <column name="log_type_ref_type" remarks="type of message causing the log" type="VARCHAR(25)"/>
             <column name="log_senderreceiver" remarks="The sender or receiver of the message logged" type="VARCHAR(50)">
                 <constraints nullable="false"/>

--- a/domain/src/main/java/eu/europa/ec/fisheries/uvms/exchange/entity/exchangelog/ExchangeLog.java
+++ b/domain/src/main/java/eu/europa/ec/fisheries/uvms/exchange/entity/exchangelog/ExchangeLog.java
@@ -58,7 +58,6 @@ public class ExchangeLog {
 	@Enumerated(EnumType.STRING)
 	private LogType type;
 	
-	@Size(max=36)
 	@Column(name="log_type_ref_guid")
 	private String typeRefGuid;
 	

--- a/domain/src/test/java/eu/europa/ec/fisheries/uvms/exchange/DomainModelBeanTest.java
+++ b/domain/src/test/java/eu/europa/ec/fisheries/uvms/exchange/DomainModelBeanTest.java
@@ -11,12 +11,26 @@ copy of the GNU General Public License along with the IFDM Suite. If not, see <h
  */
 package eu.europa.ec.fisheries.uvms.exchange;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import eu.europa.ec.fisheries.schema.exchange.service.v1.CapabilityListType;
+import eu.europa.ec.fisheries.schema.exchange.service.v1.ServiceResponseType;
+import eu.europa.ec.fisheries.schema.exchange.service.v1.ServiceType;
+import eu.europa.ec.fisheries.schema.exchange.service.v1.SettingListType;
+import eu.europa.ec.fisheries.uvms.exchange.bean.ServiceRegistryModelBean;
+import eu.europa.ec.fisheries.uvms.exchange.dao.ServiceRegistryDao;
+import eu.europa.ec.fisheries.uvms.exchange.entity.exchangelog.ExchangeLog;
+import eu.europa.ec.fisheries.uvms.exchange.entity.serviceregistry.Service;
+import eu.europa.ec.fisheries.uvms.exchange.entity.serviceregistry.ServiceCapability;
+import eu.europa.ec.fisheries.uvms.exchange.entity.serviceregistry.ServiceSetting;
+import eu.europa.ec.fisheries.uvms.exchange.exception.ExchangeDaoException;
+import eu.europa.ec.fisheries.uvms.exchange.exception.ExchangeDaoMappingException;
+import eu.europa.ec.fisheries.uvms.exchange.model.exception.ExchangeModelException;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -25,19 +39,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import eu.europa.ec.fisheries.schema.exchange.service.v1.CapabilityListType;
-import eu.europa.ec.fisheries.schema.exchange.service.v1.ServiceResponseType;
-import eu.europa.ec.fisheries.schema.exchange.service.v1.ServiceType;
-import eu.europa.ec.fisheries.schema.exchange.service.v1.SettingListType;
-import eu.europa.ec.fisheries.uvms.exchange.bean.ServiceRegistryModelBean;
-import eu.europa.ec.fisheries.uvms.exchange.dao.ServiceRegistryDao;
-import eu.europa.ec.fisheries.uvms.exchange.entity.serviceregistry.Service;
-import eu.europa.ec.fisheries.uvms.exchange.entity.serviceregistry.ServiceCapability;
-import eu.europa.ec.fisheries.uvms.exchange.entity.serviceregistry.ServiceSetting;
-import eu.europa.ec.fisheries.uvms.exchange.exception.ExchangeDaoException;
-import eu.europa.ec.fisheries.uvms.exchange.exception.ExchangeDaoMappingException;
-import eu.europa.ec.fisheries.uvms.exchange.model.exception.ExchangeModelException;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DomainModelBeanTest {
@@ -78,4 +79,14 @@ public class DomainModelBeanTest {
         //assertEquals(id.toString(), result.getId());
     }
 
+    @Test
+    public void testSizeOfGuids(){
+        ExchangeLog exchangeLog = new ExchangeLog();
+        exchangeLog.setTypeRefGuid("367637676376376337863873683763873690282082822908298");
+        exchangeLog.prepersist();
+
+        assertTrue(exchangeLog.getTypeRefGuid().length() > 36);
+        assertTrue(exchangeLog.getGuid().length() == 36);
+
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <!-- Uvms libs -->
         <longpolling.version>2.0.13</longpolling.version>
         <uvms.commons.version>3.0.17</uvms.commons.version>
-        <uvms.config.version>4.0.0</uvms.config.version>
+        <uvms.config.version>4.0.1-SNAPSHOT</uvms.config.version>
         <usm4uvms.version>4.0.8</usm4uvms.version>
         <uvms-pom-deps.version>1.16</uvms-pom-deps.version>
 


### PR DESCRIPTION
The UUID of a report can potentially be of whatever size , so no size constraint can be put on this column else the message will never get logged in the exchange log table.