### PR TITLE
Fix logging of xsd-invalid Sales message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
         <!-- Uvms models -->
         <asset.model.version>4.0.12</asset.model.version>
-        <exchange.model.version>4.0.18</exchange.model.version>
+        <exchange.model.version>4.0.19</exchange.model.version>
         <audit.model.version>4.0.8</audit.model.version>
         <movement.model.version>4.0.14</movement.model.version>
         <rules.model.version>3.0.32</rules.model.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
         <!-- Uvms models -->
         <asset.model.version>4.0.12</asset.model.version>
-        <exchange.model.version>4.0.18-SNAPSHOT</exchange.model.version>
+        <exchange.model.version>4.0.18</exchange.model.version>
         <audit.model.version>4.0.8</audit.model.version>
         <movement.model.version>4.0.14</movement.model.version>
         <rules.model.version>3.0.32</rules.model.version>

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/exchange/service/bean/ExchangeEventIncomingServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/exchange/service/bean/ExchangeEventIncomingServiceBean.java
@@ -459,7 +459,7 @@ public class ExchangeEventIncomingServiceBean implements ExchangeEventIncomingSe
         try {
             ReceiveInvalidSalesMessage request = JAXBMarshaller.unmarshallTextMessage(event.getJmsMessage(), ReceiveInvalidSalesMessage.class);
 
-            exchangeLog.log(request, LogType.RECEIVE_SALES_REPORT, ExchangeLogStatusTypeType.FAILED, TypeRefType.SALES_REPORT, request.getRespondToInvalidMessageRequest(), true);
+            exchangeLog.log(request, LogType.RECEIVE_SALES_REPORT, ExchangeLogStatusTypeType.FAILED, TypeRefType.SALES_REPORT, request.getOriginalMessage(), true);
 
             producer.sendMessageOnQueue(request.getRespondToInvalidMessageRequest(), MessageQueue.SALES);
         } catch (ExchangeLogException e) {


### PR DESCRIPTION
When a message is sent to Sales, which is not complient to the XSD, the message was not logged correctly in Exchange.