### PR TITLE
[UNIONVMS-4154] Harmonize the name of he property ListQueryResponse.logList

### DIFF
--- a/rest/src/main/java/eu/europa/ec/fisheries/uvms/exchange/rest/dto/exchange/ListQueryResponse.java
+++ b/rest/src/main/java/eu/europa/ec/fisheries/uvms/exchange/rest/dto/exchange/ListQueryResponse.java
@@ -47,8 +47,7 @@ public class ListQueryResponse {
     public void setTotalNumberOfPages(int totalNumberOfPages) {
         this.totalNumberOfPages = totalNumberOfPages;
     }
-    public List<ExchangeLogDto> getLogs() {
+    public List<ExchangeLogDto> getLogList() {
         return logList;
     }
-
 }

--- a/rest/src/main/java/eu/europa/ec/fisheries/uvms/exchange/rest/mapper/ExchangeLogMapper.java
+++ b/rest/src/main/java/eu/europa/ec/fisheries/uvms/exchange/rest/mapper/ExchangeLogMapper.java
@@ -47,7 +47,7 @@ public class ExchangeLogMapper {
         dto.setTotalNumberOfPages(response.getTotalNumberOfPages());
 
         for (ExchangeLogType log : response.getExchangeLog()) {
-            dto.getLogs().add(mapToExchangeLogDto(log));
+            dto.getLogList().add(mapToExchangeLogDto(log));
         }
 
         return dto;

--- a/rest/src/main/java/eu/europa/ec/fisheries/uvms/exchange/rest/mock/ExchangeMock.java
+++ b/rest/src/main/java/eu/europa/ec/fisheries/uvms/exchange/rest/mock/ExchangeMock.java
@@ -31,7 +31,7 @@ public class ExchangeMock {
 		ListQueryResponse response = new ListQueryResponse();
 		response.setCurrentPage(1);
 		response.setTotalNumberOfPages(1);
-		response.getLogs().addAll(mockExchangeLogList());
+		response.getLogList().addAll(mockExchangeLogList());
 		return response;
 	}
 


### PR DESCRIPTION
The original commit was meant to fix a discrepancy in the names of the fields of `ListQueryResponse`. Specifically the `private List<ExchangeLogDto> logList` was serialized through `getLogs()` as `logs` in JSON representations of this object. We corrected the discrepancy server-side.

Please merge together with the [frontend PR](https://github.com/UnionVMS/UVMS-Frontend/pull/246).