### PR TITLE
[UNIONVMS-MOVEMENT-RULES] used logid instead of message id

### DIFF
--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/exchange/service/bean/ExchangeLogServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/exchange/service/bean/ExchangeLogServiceBean.java
@@ -266,7 +266,7 @@ public class ExchangeLogServiceBean implements ExchangeLogService {
         LogWithRawMsgAndType rawMsg = exchangeLogModel.getExchangeLogRawXmlByGuid(guid);
         ExchangeLogWithValidationResults validationFromRules = new ExchangeLogWithValidationResults();
         if (rawMsg.getType() != null){
-            if (TypeRefType.FA_RESPONSE == rawMsg.getType() || TypeRefType.MOVEMENT == rawMsg.getType()){
+            if (TypeRefType.FA_RESPONSE == rawMsg.getType()){
                 guid = rawMsg.getRefGuid();
             }
             validationFromRules = exchangeToRulesSyncMsgBean.getValidationFromRules(guid, rawMsg.getType(), rawMsg.getDataFlow());


### PR DESCRIPTION
Dependecy on the following modules:
UVMS-RulesModule-APP
UVMS-MDRCacheModule-APP
UVMS-MovementModule-APP